### PR TITLE
docs: add module READMEs documenting v1.5 implementation gap

### DIFF
--- a/oesis/inference/README.md
+++ b/oesis/inference/README.md
@@ -1,0 +1,20 @@
+# oesis.inference
+
+Hazard assessment engine. Combines normalized observations + parcel context + public context into derived parcel state (smoke, heat, flood probabilities + status).
+
+## Lane structure
+
+- **Top-level** (`infer_parcel_state.py`, `parcel_first_hazard.py`, `serve_inference_api.py`): cross-version orchestrator. Dispatches per-lane behavior via `runtime_lane` parameter (see `oesis/common/runtime_lane.py`).
+- **Per-version overlay dirs** (`v0_1/` through `v0_5/`): lane-specific implementations and overrides.
+
+## v1.0 and v1.5 status
+
+| Lane | Module dir | Status |
+|---|---|---|
+| v0.1 – v0.5 | `v0_1/` – `v0_5/` | Implemented |
+| v1.0 | (no dedicated dir) | Lane-aware via top-level dispatch + `runtime_lane="v1.0"`; v1.0 inference deltas materialize through assets and config in `oesis/assets/v1.0/` |
+| **v1.5** | **(no dir)** | **Contracts present in `oesis/assets/v1.5/examples/` (6 files) but no inference module exercises them yet.** v1.5 examples are validated against contract schemas via `oesis-contracts/scripts/validate_examples.py`, but the bridge-stage inference path (house-state, intervention-event, verification-outcome → parcel-state) is not yet implemented in this module. |
+
+This is intentional — v1.5 is a draft additive lane, and runtime modules will land per their own ticketed work, not as a single lift. See [oesis-program-specs U7 #116](https://github.com/lumenaut-llc/oesis-program-specs/issues/116) for the bridge-endpoint tracker that gates this module's v1.5 work.
+
+If you're exploring the tree and wondering whether v1.5 inference modules were lost: they were never written. The assets directory mirrors the contract; the module directory mirrors what's been implemented against the contract.

--- a/oesis/ingest/README.md
+++ b/oesis/ingest/README.md
@@ -1,0 +1,27 @@
+# oesis.ingest
+
+Packet ingestion + normalization. Accepts raw packets from sensor nodes (bench-air, mast-lite, flood, weather-pm, circuit-monitor) and emits canonical normalized observations.
+
+## Module shape
+
+This module does NOT use per-version subdirectories. All normalizers live at the top level and dispatch by `schema_version` discriminator on the raw packet. Lane-aware behavior is parameterized via `runtime_lane`, not segregated into version dirs.
+
+Files:
+
+- `ingest_packet.py` — main entry point; routes by `schema_version`
+- `normalize_packet.py` — bench-air baseline normalizer (covers v0.1–v0.5 lanes)
+- `normalize_public_smoke_context.py`, `normalize_public_weather_context.py` — adapter normalizers for public context
+- `serve_ingest_api.py` — HTTP boundary
+- `serial_bridge.py` — node serial → ingest API bridge
+
+## v1.0 and v1.5 status
+
+| Surface | Status |
+|---|---|
+| `oesis.bench-air.v1` (v0.1+) | Implemented |
+| `flood.low_point.snapshot` (v0.3+) | Implemented (separate `normalize_flood_packet.py` overlay per lane) |
+| `air.pm_weather.snapshot` (v1.0) | Implemented (separate `normalize_weather_pm_packet.py` overlay per lane) |
+| `equipment.circuit.snapshot` (v1.0+) | Schema landed in oesis-contracts 2026-04-24; runtime normalizer **not yet wired** |
+| **v1.5 bridge contracts** (equipment-state-observation, source-provenance-record, etc.) | **Contracts present in `oesis/assets/v1.5/examples/` but no normalizer in this module exercises them yet.** Validation happens via `oesis-contracts/scripts/validate_examples.py`. |
+
+v1.5 ingest work is gated on the bridge-endpoint tracker [oesis-program-specs U7 #116](https://github.com/lumenaut-llc/oesis-program-specs/issues/116). If you're exploring the tree and wondering whether v1.5 normalizers were lost: they were never written.

--- a/oesis/parcel_platform/README.md
+++ b/oesis/parcel_platform/README.md
@@ -1,0 +1,26 @@
+# oesis.parcel_platform
+
+Output formatting + APIs. Builds parcel views, evidence summaries, and admin/governance surfaces from derived parcel state.
+
+## Module shape
+
+This module does NOT use per-version subdirectories. All formatters and API handlers live at the top level. Lane-aware behavior is parameterized via `runtime_lane` per call.
+
+Files:
+
+- `format_parcel_view.py` — main parcel-view renderer
+- `format_evidence_summary.py` — evidence summary builder
+- `serve_parcel_api.py` — HTTP API boundary
+- `export_parcel_bundle.py` — export-bundle generator (v0.5 governance)
+- `process_rights_requests.py` — rights-request lifecycle (v0.5 governance)
+- `run_retention_cleanup.py` — retention-cleanup utility (v0.5 governance)
+- `admin_reference_state.py` — admin reference flow
+- `reference_pipeline.py` — end-to-end reference pipeline
+
+## v1.5 bridge-object endpoints
+
+The v1.5 contracts define six bridge support objects: `house-state`, `house-capability`, `intervention-event`, `verification-outcome`, `equipment-state-observation`, `source-provenance-record`. These have schema definitions and example payloads but **no standalone `/v1/<object>` endpoints in this module yet**.
+
+The `infer_parcel_state` pipeline already CONSUMES these objects as inputs (via fixture loading), but operators cannot CREATE/UPDATE them at runtime. That's the gap.
+
+Tracked as [oesis-program-specs U7 #116](https://github.com/lumenaut-llc/oesis-program-specs/issues/116) — six child tickets for the six endpoints. If you're exploring the tree and wondering whether v1.5 endpoint code was lost: it was never written.

--- a/oesis/shared_map/README.md
+++ b/oesis/shared_map/README.md
@@ -1,0 +1,19 @@
+# oesis.shared_map
+
+Shared neighborhood-signal aggregation. Produces opt-in cross-parcel summaries with consent gating, custody-tier enforcement, and minimum-participation thresholding.
+
+## Lane structure
+
+- **Top-level** (`aggregate_shared_map.py`, `serve_shared_map_api.py`): cross-version orchestrator
+- **Per-version overlay dirs** (`v0_1/` through `v1_0/`): lane-specific implementations and overrides
+
+## v1.5 status
+
+There is **no `v1_5/` dir in this module.** v1.5 is the bridge-stage capability lane (house-state, intervention-event, verification-outcome). Bridge-stage objects are private-by-default; they don't have shared-map projections defined yet. Whether the shared-map surface should expose any bridge-stage signal at all is itself an open design question (see UA2 contribution-schema design thread).
+
+If `v1_5/` later appears here, it would carry whatever cross-parcel projection is approved for bridge-stage signals — likely a small, heavily-gated subset rather than direct mirroring of the bridge objects.
+
+Cross-references:
+
+- v1.5 bridge-object tracker: [oesis-program-specs U7 #116](https://github.com/lumenaut-llc/oesis-program-specs/issues/116)
+- Contribution-schema design thread: [oesis-program-specs UA2 #62](https://github.com/lumenaut-llc/oesis-program-specs/issues/62)


### PR DESCRIPTION
## Summary

Closes #14. Audit follow-up #2 — addresses weakness #3 from the 2026-04-25 multi-repo audit (v1.5 asymmetry across repos with no documented gap).

## What changed

Added 4 module READMEs that previously didn't exist:

- `oesis/inference/README.md`
- `oesis/ingest/README.md`
- `oesis/parcel_platform/README.md`
- `oesis/shared_map/README.md`

Each README:
- Describes the module's purpose
- Documents the lane structure honestly (per-module variation: `inference` and `shared_map` use per-version subdirs; `ingest` and `parcel_platform` are flat with `runtime_lane` dispatch)
- Explicitly notes the v1.5 gap: contracts present in `oesis/assets/v1.5/`, no module code exercises them yet
- Cross-references the [oesis-program-specs U7 #116](https://github.com/lumenaut-llc/oesis-program-specs/issues/116) bridge-endpoint tracker that gates v1.5 module work

## Per-module honesty notes (surfaced while writing)

- **inference**: missing dedicated `v1_5/` dir; also no `v1_0/` dir (v1.0 handled via top-level dispatch — intentional)
- **ingest**: never had per-version dirs; `equipment.circuit.snapshot` schema landed in contracts 2026-04-24 but normalizer not yet wired
- **parcel_platform**: bridge objects already consumed by inference but no standalone `/v1/<object>` endpoints — that's the gap, tracked as 6 child tickets under U7 #116
- **shared_map**: no `v1_5/` dir; whether bridge-stage signals should have shared-map projections is itself an open design question ([UA2 #62](https://github.com/lumenaut-llc/oesis-program-specs/issues/62))

## What did NOT change

- No code changes
- No structural changes
- `.DS_Store` files in working tree are NOT being added/removed in this PR (separate cleanup)
- +92 lines, 0 lines removed

## Test plan
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)