### PR TITLE
chore(assets): mirror v1.0 admissibility-fact examples (G17)

### DIFF
--- a/oesis/assets/v1.0/examples/node-observation-mast-lite.example.json
+++ b/oesis/assets/v1.0/examples/node-observation-mast-lite.example.json
@@ -24,6 +24,12 @@
     "pressure_hpa": 1012.4,
     "voc_trend_source": "gas_resistance_ohm"
   },
+  "burn_in_complete": true,
+  "node_calibration_session_ref": "calsession:mast-lite-01:2026-04-15T11:00:00Z",
+  "node_deployment_maturity": "v1.0",
+  "node_deployment_class": "sheltered",
+  "protective_fixture_verified_at": "2026-04-15T11:30:00Z",
+  "placement_representativeness_class": "B",
   "health": {
     "uptime_s": 5420,
     "wifi_connected": true,

--- a/oesis/assets/v1.0/examples/node-observation.example.json
+++ b/oesis/assets/v1.0/examples/node-observation.example.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "oesis.bench-air.v1",
+  "node_id": "bench-air-01",
+  "observed_at": "2026-04-28T19:45:00Z",
+  "firmware_version": "1.0.0",
+  "location_mode": "indoor",
+  "sensors": {
+    "sht45": {
+      "present": true,
+      "temperature_c": 23.4,
+      "relative_humidity_pct": 41.8
+    },
+    "bme680": {
+      "present": true,
+      "temperature_c": 24.1,
+      "relative_humidity_pct": 40.9,
+      "pressure_hpa": 1012.6,
+      "gas_resistance_ohm": 145230
+    }
+  },
+  "derived": {
+    "temperature_c_primary": 23.4,
+    "relative_humidity_pct_primary": 41.8,
+    "pressure_hpa": 1012.6,
+    "voc_trend_source": "gas_resistance_ohm"
+  },
+  "burn_in_complete": true,
+  "node_calibration_session_ref": "calsession:bench-air-01:2026-04-22T14:30:00Z",
+  "node_deployment_maturity": "v1.0",
+  "node_deployment_class": "indoor",
+  "protective_fixture_verified_at": null,
+  "placement_representativeness_class": "B",
+  "health": {
+    "uptime_s": 1820,
+    "wifi_connected": true,
+    "free_heap_bytes": 214332,
+    "read_failures_total": 0,
+    "last_error": null
+  }
+}


### PR DESCRIPTION
## Summary

Mirrors oesis-contracts v1.0 examples after the G17 schema extension in [oesis-contracts#11](https://github.com/lumenaut-llc/oesis-contracts/pull/11).

This is a runtime-fixture sync; no validator changes. The actual admissibility-decision computation is tracked separately as G15 in this repo.

## Changes

- `oesis/assets/v1.0/examples/node-observation.example.json` — new v1.0 canonical example with all six admissibility facts populated
- `oesis/assets/v1.0/examples/node-observation-mast-lite.example.json` — updated to populate the new facts at v1.0 cadence

Generated mechanically by `python3 scripts/repo_split.py sync-runtime-assets` from oesis-program-specs.

## Why these are accepted as-is

The existing hand-coded `validate_node_observation` in `oesis/ingest/v1_0/validate_examples.py` doesn't enforce `additionalProperties: false`, so the new optional fields pass through silently. Verified locally via the new pre-fanout check (`oesis-contracts/scripts/check_runtime_compat.py`).

A separate G15 runtime PR will add the admissibility-decision computation that consumes these facts.

## Sequencing

This PR should merge **after** oesis-contracts#11 — otherwise cross-repo sync would flag the runtime-side examples as ahead of contracts.

## Test plan

- [ ] All lane CI jobs green (v0.1 through v0.5 and v1.0)
- [ ] Cross-repo sync clean (run from oesis-program-specs after both PRs land)

🤖 Generated with [Claude Code](https://claude.com/claude-code)