### PR TITLE
chore(assets): mirror v1.5 adapter-trust facts (G18)

### DIFF
--- a/oesis/assets/v1.5/examples/source-provenance-record.example.json
+++ b/oesis/assets/v1.5/examples/source-provenance-record.example.json
@@ -18,7 +18,12 @@
         "intervention_context",
         "verification_context"
       ],
-      "raw_ref": "obs_hvac_ct_0007"
+      "raw_ref": "obs_hvac_ct_0007",
+      "adapter_source_ref": "adapter:ct_clamp_hvac/v1.0/source-authority.md",
+      "adapter_contract_version": "ct-clamp-hvac.v1.2",
+      "adapter_onboarding_ref": "onboarding:parcel_demo_001:ct_clamp_hvac:2026-04-01T15:00:00Z",
+      "adapter_credential_last_verified_at": "2026-04-14T08:00:00Z",
+      "adapter_tier": "tier_2_adapter"
     },
     {
       "signal_key": "outdoor_air_intake",


### PR DESCRIPTION
## Summary

Mirrors oesis-contracts v1.5 example after the G18 schema extension in [oesis-contracts#TBD](https://github.com/lumenaut-llc/oesis-contracts).

The \`source-provenance-record\` example now populates the five adapter-trust facts on its \`adapter_derived\` record:

- \`adapter_source_ref\`
- \`adapter_contract_version\`
- \`adapter_onboarding_ref\`
- \`adapter_credential_last_verified_at\`
- \`adapter_tier\`

Generated mechanically by \`python3 scripts/repo_split.py sync-runtime-assets\` from oesis-program-specs.

## Why this is accepted as-is

Runtime's existing hand-coded \`validate_source_provenance_record\` doesn't enforce \`additionalProperties\` or the new conditional requirement (\`required when source_kind == "adapter_derived"\`). The new fields pass through silently. Verified locally via \`scripts/check_runtime_compat.py\` in oesis-contracts.

A separate runtime PR (under G15) will extend the validator + add adapter-trust §C admissibility computation.

## Sequencing

This PR should merge **after** the contracts PR — otherwise cross-repo sync would flag the runtime-side example as ahead of contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)