### PR TITLE
feat(ingest): G15 step 2 — wire compute_admissibility into v1.0 normalize_packet

### DIFF
--- a/oesis/checks/v1_0/acceptance.py
+++ b/oesis/checks/v1_0/acceptance.py
@@ -262,11 +262,51 @@ def verify_value_assertions(payload: dict) -> None:
         raise SystemExit(f"freshness seconds_since_latest negative: {secs}")
 
 
+def verify_admissibility_stamping(payload: dict) -> None:
+    """Assert G15 step 2: every bench-air normalized observation in the v1.0
+    flow carries admissibility decision fields (per ADR 0009).
+
+    The values themselves vary with whether the example fixture populated
+    the calibration §C facts — the v0.1-era fixtures used by build_default_bundle
+    will be inadmissible (correct policy outcome). What we enforce here is
+    that the FIELDS are present, not that any particular fixture is admissible.
+    """
+    normalized = payload["normalized_observation"]
+    if "admissible_to_calibration_dataset" not in normalized:
+        raise SystemExit(
+            "v1.0 acceptance: normalized_observation missing admissible_to_calibration_dataset "
+            "(G15 step 2 wiring regression)"
+        )
+    if "admissibility_reasons" not in normalized:
+        raise SystemExit(
+            "v1.0 acceptance: normalized_observation missing admissibility_reasons "
+            "(G15 step 2 wiring regression)"
+        )
+    admissible = normalized["admissible_to_calibration_dataset"]
+    reasons = normalized["admissibility_reasons"]
+    if not isinstance(admissible, bool):
+        raise SystemExit(f"admissible_to_calibration_dataset must be bool, got {type(admissible).__name__}")
+    if not isinstance(reasons, list):
+        raise SystemExit(f"admissibility_reasons must be list, got {type(reasons).__name__}")
+    # Invariant: admissible iff reasons is empty.
+    if admissible and reasons:
+        raise SystemExit(f"admissible=True but reasons populated: {reasons}")
+    if not admissible and not reasons:
+        raise SystemExit("admissible=False but reasons list is empty (rule engine should have populated codes)")
+
+    # Same invariants on mast-lite if present in this flow.
+    if "mast_lite_normalized" in payload:
+        ml = payload["mast_lite_normalized"]
+        if "admissible_to_calibration_dataset" not in ml or "admissibility_reasons" not in ml:
+            raise SystemExit("v1.0 acceptance: mast_lite_normalized missing admissibility fields")
+
+
 def main() -> None:
     payload = build_v10_runtime_flow()
     verify_runtime_flow_artifacts(payload)
     verify_trust_score(payload)
     verify_value_assertions(payload)
+    verify_admissibility_stamping(payload)
     # Mast-lite assertions
     if "mast_lite_normalized" not in payload:
         raise SystemExit("v1.0 acceptance: mast_lite_normalized missing from flow")

--- a/oesis/ingest/v1_0/normalize_packet.py
+++ b/oesis/ingest/v1_0/normalize_packet.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from oesis.common.repo_paths import EXAMPLES_DIR
 from oesis.common.runtime_lane import resolve_runtime_lane, versioning_payload
 
+from .admissibility import compute_admissibility
 from .normalize_circuit_packet import normalize_circuit_packet as _normalize_circuit
 from .normalize_flood_packet import normalize_flood_packet as _normalize_flood
 from .normalize_weather_pm_packet import normalize_weather_pm_packet as _normalize_weather_pm
@@ -33,6 +34,47 @@ def get_bme_payload(sensors: dict) -> dict:
 
 def has_value(payload: dict, field_name: str) -> bool:
     return field_name in payload and payload[field_name] is not None
+
+
+def build_admissibility_facts(payload: dict) -> dict:
+    """
+    Extract admissibility facts from a raw bench-air payload.
+
+    Per ADR 0009 / G17, the v1.0 node-observation schema carries six optional
+    calibration §C fact fields. We pass them straight through to
+    compute_admissibility along with identity, location_mode, and health —
+    the pure function tolerates missing keys (each absence becomes its
+    own reason code, which is the policy-correct outcome).
+
+    The v0.1-era payloads (no admissibility fact fields) flow through the
+    same path; they will be stamped inadmissible with multiple reason
+    codes — this is intentional. v0.1 fixtures should not be admitted to
+    coefficient fitting until producers emit the v1.0 facts.
+    """
+    return {
+        # Identity (§C check 1)
+        "node_id": payload.get("node_id"),
+        "firmware_version": payload.get("firmware_version"),
+        # Producer-side intent vs verified install (§C check 3)
+        "location_mode": payload.get("location_mode"),
+        "node_deployment_class": payload.get("node_deployment_class"),
+        # Maturity (§C check 2)
+        "node_deployment_maturity": payload.get("node_deployment_maturity"),
+        # Burn-in (§C check 4)
+        "burn_in_complete": payload.get("burn_in_complete"),
+        # Reference calibration (§C check 5). The schema carries
+        # node_calibration_session_ref (string pointer) only; if a producer
+        # also stamps node_calibration_verified_at the cadence check fires,
+        # otherwise the reason code is gated on session_ref alone.
+        "node_calibration_session_ref": payload.get("node_calibration_session_ref"),
+        "node_calibration_verified_at": payload.get("node_calibration_verified_at"),
+        # Placement representativeness (§C check 6)
+        "placement_representativeness_class": payload.get("placement_representativeness_class"),
+        # Protective fixture (§C check 7)
+        "protective_fixture_verified_at": payload.get("protective_fixture_verified_at"),
+        # Sensor health (§C check 8)
+        "health": payload.get("health", {}),
+    }
 
 
 def build_values(payload: dict) -> dict:
@@ -95,6 +137,11 @@ def normalize_packet(
     ingested_at = ingested_at or now_iso()
     resolved_lane = resolve_runtime_lane(runtime_lane)
 
+    # Compute admissibility per calibration-program §C / ADR 0009.
+    # Bench-air packets always route to the physical-sensor path (tier=None);
+    # adapter-derived sources flow through source-provenance-record, not here.
+    admissibility = compute_admissibility(build_admissibility_facts(payload))
+
     normalized = {
         "observation_id": make_ref("obs"),
         "node_id": payload["node_id"],
@@ -114,6 +161,11 @@ def normalize_packet(
             "firmware_version": payload["firmware_version"],
             "raw_packet_ref": make_ref("rawpkt"),
         },
+        # Per ADR 0009: admissibility decision lives on normalized observations
+        # only, never back-propagated to the canonical schema. Empty reasons
+        # list when admissible; populated reason codes when not.
+        "admissible_to_calibration_dataset": admissibility.admissible,
+        "admissibility_reasons": admissibility.reasons,
         "versioning": versioning_payload(lane=resolved_lane),
         "raw_packet": payload,
     }


### PR DESCRIPTION
## Summary

Stamps every bench-air normalized observation with admissibility decision fields per ADR 0009 — schema carries facts, runtime computes decision. Builds on G15 step 1 ([oesis_runtime#24](https://github.com/lumenaut-llc/oesis_runtime/pull/24)) which shipped the pure rule engine.

Output added to every normalized observation (v1.0 lane bench-air path):
- \`admissible_to_calibration_dataset: bool\`
- \`admissibility_reasons: [string]\`

## What's added

- **\`oesis/ingest/v1_0/normalize_packet.py\`** — new helper \`build_admissibility_facts(payload)\` extracts the six v1.0 calibration §C facts plus identity / location_mode / health from the raw payload. \`normalize_packet\` calls \`compute_admissibility(facts)\` and attaches output to the normalized observation.
- **\`oesis/checks/v1_0/acceptance.py\`** — new \`verify_admissibility_stamping\` enforces:
  - Both fields present
  - \`admissible\` is bool, \`admissibility_reasons\` is list
  - Invariant: \`admissible\` iff \`reasons == []\`

## Behavioral verification (manual)

- **v1.0 example** (\`oesis/assets/v1.0/examples/node-observation.example.json\`, has all 6 facts) → admissible, empty reasons
- **v0.1-era fixtures** (no facts) → inadmissible with reason codes for the missing facts. **This is the policy-correct outcome** — v0.1 observations shouldn't be admitted to coefficient fitting until producers emit the v1.0 facts.

The acceptance test asserts the *invariant*, not that any particular fixture is admissible. So the test stays green regardless of which fixture flows through.

## CI evidence

\`\`\`
$ for lane in v0.1 v0.2 v0.3 v0.4 v0.5 v1.0; do OESIS_RUNTIME_LANE=$lane python3 -m oesis.checks; done
PASS oesis.checks v0.1 offline
PASS oesis.checks v0.2 offline
PASS oesis.checks v0.3 offline
PASS oesis.checks v0.4 offline
PASS oesis.checks v0.5 offline
PASS oesis.checks v1.0 offline

$ python3 -m oesis.checks.v1_0.admissibility_check
28/28 passed
\`\`\`

## Scope (deliberate)

In scope:
- v1.0 bench-air path only (this is where the G17 facts land)

Out of scope (deferred to follow-ups):
- v0.1 normalizer is unchanged — admissibility is a v1.0+ concept and v0.1 doesn't carry the schema facts
- flood/circuit/weather-pm sub-normalizers carry different fact sets and need their own wiring
- adapter-derived sources flow through source-provenance-record (G18), not node-observation — adapter §C admissibility wiring is a different code path

## Step 3 preview

The remaining G15 work: \`infer_parcel_state.py\` reads \`admissible_to_calibration_dataset\` and surfaces \`admissibility_reasons\` in the explanation payload. Independent of this PR.

## Test plan

- [ ] All 9 CI checks green (3 Python versions × 3 lanes + verify-examples)
- [ ] Lane acceptance tests still PASS for v0.1-v0.5 and v1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)