### PR TITLE
feat(inference): G15 step 3 — surface admissibility in explanation payload

### DIFF
--- a/oesis/checks/v1_0/acceptance.py
+++ b/oesis/checks/v1_0/acceptance.py
@@ -301,12 +301,54 @@ def verify_admissibility_stamping(payload: dict) -> None:
             raise SystemExit("v1.0 acceptance: mast_lite_normalized missing admissibility fields")
 
 
+def verify_admissibility_in_explanation(payload: dict) -> None:
+    """Assert G15 step 3: inference surfaces admissibility in the explanation
+    payload.
+
+    The structured object is the durable artifact (per ADR 0009). Existing UX
+    renderers also see a human-readable line in `limitations` when the
+    observation is inadmissible.
+    """
+    parcel_state = payload["parcel_state"]
+    if "explanation_payload" not in parcel_state:
+        raise SystemExit("v1.0 acceptance: parcel_state missing explanation_payload (G15 step 3)")
+    ep = parcel_state["explanation_payload"]
+
+    # Structured admissibility object should be present on v1.0 since ingest
+    # stamps it. Absence is a wiring regression.
+    if "admissibility" not in ep:
+        raise SystemExit(
+            "v1.0 acceptance: explanation_payload missing admissibility object "
+            "(G15 step 3 wiring regression — ingest stamps it but inference dropped it)"
+        )
+    a = ep["admissibility"]
+    if "admissible_to_calibration_dataset" not in a or "admissibility_reasons" not in a:
+        raise SystemExit(f"explanation_payload.admissibility shape wrong: {a}")
+    if not isinstance(a["admissible_to_calibration_dataset"], bool):
+        raise SystemExit("admissible_to_calibration_dataset must be bool")
+    if not isinstance(a["admissibility_reasons"], list):
+        raise SystemExit("admissibility_reasons must be list")
+
+    # When inadmissible, the FIRST limitations entry must be the rendered
+    # admissibility line — UX expects to render it prominently.
+    if not a["admissible_to_calibration_dataset"]:
+        limitations = ep.get("limitations", [])
+        if not limitations:
+            raise SystemExit("inadmissible observation but limitations list is empty")
+        if "not admissible to the calibration dataset" not in limitations[0]:
+            raise SystemExit(
+                f"inadmissible observation: limitations[0] should render admissibility line, "
+                f"got: {limitations[0]!r}"
+            )
+
+
 def main() -> None:
     payload = build_v10_runtime_flow()
     verify_runtime_flow_artifacts(payload)
     verify_trust_score(payload)
     verify_value_assertions(payload)
     verify_admissibility_stamping(payload)
+    verify_admissibility_in_explanation(payload)
     # Mast-lite assertions
     if "mast_lite_normalized" not in payload:
         raise SystemExit("v1.0 acceptance: mast_lite_normalized missing from flow")

--- a/oesis/inference/v1_0/infer_parcel_state.py
+++ b/oesis/inference/v1_0/infer_parcel_state.py
@@ -1557,6 +1557,51 @@ def confidence_band(confidence: float) -> str:
     return "low"
 
 
+_ADMISSIBILITY_REASON_PROSE = {
+    # Calibration-program §C reason codes
+    "node_identity_missing": "node identity not registered for this parcel",
+    "deployment_maturity_insufficient": "node has not reached deployment maturity v1.0",
+    "deployment_class_mismatch": "deployment class disagrees with installation declaration",
+    "burn_in_incomplete": "sensor burn-in window has not completed",
+    "reference_calibration_stale": "reference calibration is missing or beyond cadence",
+    "representativeness_class_d": "placement representativeness is unfit for shared inference",
+    "fixture_unverified": "protective fixture has not passed acceptance test",
+    "sensor_health_degraded": "sensor read failures detected since last reset",
+    # Adapter-trust §C reason codes
+    "adapter_source_missing": "adapter source authority file is not registered",
+    "contract_version_drift": "adapter contract version drifted from pinned version",
+    "onboarding_missing": "adapter onboarding gate has not passed for this parcel",
+    "credentials_expired": "adapter credentials are expired or never verified",
+    "cadence_stale": "adapter reading is stale beyond refresh cadence",
+    "tier_insufficient": "adapter tier does not satisfy the consumer's trust requirement",
+    "uncertainty_out_of_bounds": "adapter-reported uncertainty exceeds spec bound",
+    "source_incident_open": "adapter source has an open incident or deprecation",
+}
+
+
+def _admissibility_limitation_summary(reasons: list[str]) -> str | None:
+    """Render an inadmissibility reason list as a single human-readable line.
+
+    Used as a `limitations` entry in the explanation payload so existing UX
+    renderers naturally surface the policy reasons without needing to read
+    the structured `admissibility` object. None when the observation is
+    admissible (no surfacing needed).
+    """
+    if not reasons:
+        return None
+    rendered = []
+    for code in reasons[:3]:  # cap at 3 to keep the line readable
+        prose = _ADMISSIBILITY_REASON_PROSE.get(code, code)
+        rendered.append(prose)
+    suffix = "" if len(reasons) <= 3 else f" (+{len(reasons) - 3} more)"
+    return (
+        "Observation is not admissible to the calibration dataset: "
+        + "; ".join(rendered)
+        + suffix
+        + "."
+    )
+
+
 def build_explanation_payload(
     *,
     confidence: float,
@@ -1569,6 +1614,8 @@ def build_explanation_payload(
     parcel_context: dict | None,
     shared_context: dict | None,
     public_context: dict | None,
+    admissible_to_calibration_dataset: bool | None = None,
+    admissibility_reasons: list[str] | None = None,
 ) -> dict:
     sorted_drivers = sorted(
         (item for item in evidence_contributions if item["role"] == "driver"),
@@ -1582,6 +1629,16 @@ def build_explanation_payload(
     )
     drivers = [item["summary"] for item in sorted_drivers[:3]]
     limitations = [item["summary"] for item in sorted_limitations[:3]]
+
+    # Surface inadmissibility as a high-priority limitation entry. Existing
+    # UX renderers that read `limitations` get the policy reason for free
+    # without needing to know about the admissibility schema.
+    admissibility_line = _admissibility_limitation_summary(admissibility_reasons or [])
+    if admissibility_line:
+        limitations = [admissibility_line] + limitations
+        # Re-cap to 3 so the field stays readable.
+        limitations = limitations[:3]
+
     if not limitations:
         limitations = ["Evidence limits are currently low enough that few explicit caveats were generated."]
 
@@ -1590,7 +1647,7 @@ def build_explanation_payload(
         f"{confidence_band(confidence)} confidence."
     )
 
-    return {
+    payload = {
         "headline": headline,
         "basis": {
             "evidence_mode": evidence_mode,
@@ -1611,6 +1668,17 @@ def build_explanation_payload(
         "divergence_summary": [item["contrast"]["summary"] for item in contrastive_explanations[:2]],
         "top_divergence_records": divergence_records[:3],
     }
+
+    # Per ADR 0009: structured admissibility object is the durable artifact.
+    # Only surface when ingest actually stamped a decision on the observation
+    # (v0.1 lane normalizers don't, so absence is meaningful — don't fabricate).
+    if admissible_to_calibration_dataset is not None:
+        payload["admissibility"] = {
+            "admissible_to_calibration_dataset": admissible_to_calibration_dataset,
+            "admissibility_reasons": list(admissibility_reasons or []),
+        }
+
+    return payload
 
 
 def circuit_observation_to_equipment_state(normalized_circuit: dict) -> dict:
@@ -1877,6 +1945,12 @@ def infer_parcel_state(
         parcel_context=parcel_context,
         shared_context=shared_context,
         public_context=public_context,
+        # G15 step 3: pass through admissibility decision attached by ingest
+        # (G15 step 2). Absent on v0.1 lane normalized observations; present
+        # on v1.0+ bench-air normalized observations. None signals "ingest
+        # did not stamp a decision," not "decision was admissible."
+        admissible_to_calibration_dataset=payload.get("admissible_to_calibration_dataset"),
+        admissibility_reasons=payload.get("admissibility_reasons"),
     )
 
     trust_score = compute_trust_score(


### PR DESCRIPTION
## Summary

Closes the G15 loop end-to-end. Inference now reads the admissibility decision attached by ingest (G15 step 2, [runtime#25](https://github.com/lumenaut-llc/oesis_runtime/pull/25)) and surfaces it in the explanation payload two ways:

1. **Structured \`admissibility\` object** — durable artifact per ADR 0009
2. **Human-readable line in \`limitations\`** when inadmissible — placed first so existing UX renderers naturally surface it

## Changes

- **\`oesis/inference/v1_0/infer_parcel_state.py\`** — \`build_explanation_payload\` takes new optional kwargs \`admissible_to_calibration_dataset\` and \`admissibility_reasons\`. Call site reads \`payload.get(...)\` so v0.1 lane (no field stamped) doesn't fabricate one. Reason codes are mapped to plain prose via a 16-entry table covering all 8 calibration §C and all 8 adapter §C codes.
- **\`oesis/checks/v1_0/acceptance.py\`** — new \`verify_admissibility_in_explanation\` enforces the structured object's presence + shape + that \`limitations[0]\` renders the policy line when inadmissible.

## End-to-end trace

With v0.1 fixture flowing through v1.0 runtime (default acceptance scenario):

\`\`\`
ingest stamps:
  admissible_to_calibration_dataset = false
  admissibility_reasons = [
    "deployment_maturity_insufficient",
    "deployment_class_mismatch",
    "burn_in_incomplete",
    "reference_calibration_stale",
    "representativeness_class_d"
  ]

inference renders into parcel_state.explanation_payload:
  admissibility = { ...same five codes... }
  limitations[0] = "Observation is not admissible to the calibration dataset:
                    node has not reached deployment maturity v1.0;
                    deployment class disagrees with installation declaration;
                    sensor burn-in window has not completed (+2 more)."
\`\`\`

This is the policy-correct outcome — v0.1 fixtures should not be admissible until producers emit the v1.0 facts.

## CI evidence

\`\`\`
$ for lane in v0.1 v0.2 v0.3 v0.4 v0.5 v1.0; do OESIS_RUNTIME_LANE=$lane python3 -m oesis.checks; done
6/6 lanes: PASS
\`\`\`

## G15 program status (full closure)

| Step | What | PR |
|---|---|---|
| 1 | \`compute_admissibility\` pure function + 28-test suite | [#24](https://github.com/lumenaut-llc/oesis_runtime/pull/24) |
| 2 | Pipeline integration in \`normalize_packet\` | [#25](https://github.com/lumenaut-llc/oesis_runtime/pull/25) |
| 3 | Inference surfacing in explanation payload | this PR |

## Out of scope (deferred follow-ups)

- Adapter §C surfacing on the source-provenance-record path (different code path)
- Flood/circuit/weather-pm sub-normalizers similarly need their own admissibility wiring
- v0.1 lane stays unchanged — admissibility is a v1.0+ concept

## Test plan

- [ ] All 9 CI checks green (3 Python versions × 3 lanes + verify-examples)
- [ ] Lane acceptance tests still PASS for v0.1-v0.5 and v1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)